### PR TITLE
fix typo in order pages section

### DIFF
--- a/docs/case_insensitive.rst
+++ b/docs/case_insensitive.rst
@@ -10,7 +10,7 @@ Whenever we try to do :code:`order_by` with some string value, the ordering happ
     >>> User.objects.all().order_by('username').values_list('username', flat=True)
     <QuerySet ['Billy', 'John', 'Radha', 'Raghu', 'Ricky', 'Ritesh', 'johny', 'johny1', 'paul', 'rishab', 'sharukh', 'sohan', 'yash']>
 
-If we want to order queryset in case insensitive manner, we can do like this . ::
+If we want to order queryset in case insensitive manner, we can do like this.
 
 .. code-block:: ipython
 

--- a/docs/order_by_two.rst
+++ b/docs/order_by_two.rst
@@ -3,7 +3,7 @@ How to order on two fields
 
 :code:`order_by` on querysets can take one or more attribute names, allowing you to order on two or more fields.
 
-..code-block:: ipython
+.. code-block:: ipython
 
     In [5]: from django.contrib.auth.models import User
 


### PR DESCRIPTION
- case_insensitive.rst, removed `::` at last paragraph "we can do like this"
- order_by_two.rst, added `space` between `..` and `code-block::`