### PR TITLE
fixed the code block definition

### DIFF
--- a/docs/order_by_two.rst
+++ b/docs/order_by_two.rst
@@ -3,7 +3,7 @@ How to order on two fields
 
 :code:`order_by` on querysets can take one or more attribute names, allowing you to order on two or more fields.
 
-..code-block:: ipython
+.. code-block:: ipython
 
     In [5]: from django.contrib.auth.models import User
 


### PR DESCRIPTION
`..code-block:: ipython` is not valid definition and unrecognized by the parser.
which leads to unwanted rendering here:
https://books.agiliq.com/projects/django-orm-cookbook/en/latest/order_by_two.html